### PR TITLE
Fix version requirement syntax

### DIFF
--- a/Markdown/Markdown.php
+++ b/Markdown/Markdown.php
@@ -30,7 +30,7 @@ class MarkdownPlugin extends MantisFormattingPlugin {
 		$this->page        = 'config';
 		$this->version     = '1.1.3';
 		$this->requires    = array(
-			'MantisCore'           => '1.2.0, 1.3.0',
+			'MantisCore'           => '1.2.0, < 1.3.0',
 			'MantisCoreFormatting' => '1.0a',
 		);
 		$this->author  = 'Frank Bültge';


### PR DESCRIPTION
This proposed change is to allow installation on 1.2 versions of mantis BT.  Otherwise, there is an "outdated dependencies" error  shown by the `/manage_plugin_page.php` page.  If this plugin is compatible with 1.3, then the `<` should be a `<=` instead
